### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "echo hello world"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Box-Eater
+[![Run on Repl.it](https://repl.it/badge/github/CousinAle/Box-Eater)](https://repl.it/github/CousinAle/Box-Eater)# Box-Eater
 I learned to type python with Turtle from a helpful tutorial on Repl.it. The objective of the game is to land (or eat) all the boxes then you win. I imported the turtle package. You cannot run this program through the command prompt of windows (terminal for mac and linux) because the hex decimal font is not supported. Please run it though Repl.it and use the python with turtle graphics and run it. Just copy and past the Box_Eater.py file code. If you know how to fix my problem with cmd please make a pull request. And even if its not that its always great to make pull requests and report issues because "the more you know". 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Faheem1234/Box-Eater).